### PR TITLE
10 feature set up automated testing with GitHub actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       POSTGRES_PASSWORD: postgres
       POSTGRES_HOST: 127.0.0.1
       POSTGRES_PORT: 5432
-      DJANGO_SETTINGS_MODULE: dweller.settings
+      DJANGO_SETTINGS_MODULE: dwellr.settings
 
     services:
       postgres:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,4 +52,5 @@ jobs:
 
     - name: Run Tests
       run: |
+        export PYTHONPATH=$PYTHONPATH:$(pwd)/dweller
         pipenv run pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
     branches: [ "main" ]
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 2
@@ -36,7 +36,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -46,6 +46,9 @@ jobs:
         pip install pipenv
         pipenv install --deploy --dev
 
+    - name: Wait for PostgreSQL to be ready
+      run: sleep 5
+
     - name: Run Tests
       run: |
-        pytest
+        pipenv run pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,51 @@
+name: Django CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 2
+      matrix:
+        python-version: [3.11, 3.12]
+    
+    env:
+      POSTGRES_DB: dweller_test_db
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_HOST: 127.0.0.1
+      POSTGRES_PORT: 5432
+
+    services:
+      postgres:
+        image: postgres:latest
+        env:
+          POSTGRES_USER: ${{env.POSTGRES_USER}}
+          POSTGRES_PASSWORD: ${{env.POSTGRES_PASSWORD}}
+          POSTGRES_DB: ${{env.POSTGRES_DB}}
+        ports:
+          - 5432:5432
+
+    steps:
+    - name: Checkout repository code
+      uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install Dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pipenv
+        pipenv install --deploy --dev
+
+    - name: Run Tests
+      run: |
+        pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
       POSTGRES_PASSWORD: postgres
       POSTGRES_HOST: 127.0.0.1
       POSTGRES_PORT: 5432
+      DJANGO_SETTINGS_MODULE: dweller.settings
 
     services:
       postgres:

--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ name = "pypi"
 psycopg = "*"
 django = "*"
 django-tailwind = {extras = ["reload"], version = "*"}
+python-dotenv = "*"
 
 [dev-packages]
 pytest-django = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "35e588b25f0d4c3beb5473c609f9efeeb3b62a20fafdb6e4414cdabda2600d03"
+            "sha256": "209a4b6c73d432c2cecc2c61cb82bdd408f7338921d205b3a24ecd68a45b7720"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -60,6 +60,15 @@
             "index": "pypi",
             "markers": "python_version >= '3.8'",
             "version": "==3.2.5"
+        },
+        "python-dotenv": {
+            "hashes": [
+                "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca",
+                "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==1.0.1"
         },
         "sqlparse": {
             "hashes": [

--- a/dweller/dwellr/settings.py
+++ b/dweller/dwellr/settings.py
@@ -12,7 +12,8 @@ https://docs.djangoproject.com/en/5.1/ref/settings/
 
 import os
 from pathlib import Path
-
+from dotenv import load_dotenv
+load_dotenv()
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
@@ -94,9 +95,11 @@ WSGI_APPLICATION = 'dwellr.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
-        'NAME': 'dweller_db',
-        'HOST': '127.0.0.1',
-        'POST': '5432'
+        'NAME': os.getenv('POSTGRES_DB', 'dweller_db'),
+        'USER': os.getenv('POSTGRES_USER', ''),
+        'PASSWORD': os.getenv('POSTGRES_PASSWORD', ''),
+        'HOST': os.getenv('POSTGRES_HOST', '127.0.0.1'),
+        'PORT': os.getenv('POSTGRES_PORT', '5432')
     }
 }
 


### PR DESCRIPTION
Description
For issue #10 Set up automated testing with GitHub actions

What:
- Created .github/workflows/test.yml using the GitHub-recommended Django workflow as a starting point.
- Configured it to run tests on push & PRs
- Used PostgreSQL as a service
- set up a matrix strategy to test on Python 3.11 & 3.12 (no reason other than it was interesting to learn about it)
- Configured Env Variables
- Defined DJANGO_SETTINGS_MODULE in test.yml so Django could load settings.

Why:
- Used Env Variables as simple to do and often the recommended approach. 
- Didn't need to use secrets as the env variables are just for tests and not for production.
- Needed to add DJANGO_SETTINGS_MODULE as it couldn't detect where settings.py was. 

Problems & Result:
- django.core.exceptions.ImproperlyConfigured
- DJANGO_SETTINGS_MODULE wasn't set, so Django didn't know where settings.py was.
- Added it to the test.yml
- ImportError: No module named 'dwellr'
- pytest-django couldn't find manage.py because dweller/wasn't in PYTHONPATH.
- Added the python path before running tests

What I learnt:
- Django needs DJANGO_SETTINGS_MODULE set explicitly in CI/CD since GitHub Actions starts in a fresh environment.
- Python's import system requires the project directory in PYTHONPATH when running tests in CI/CD
- PostgreSQL services in GitHub Actions need a short wait time to ensure it's ready before tests run.
- Matrix testing lets you test multiple Python versions in parallel without extra work.
- GitHub Actions runs commands from the repo root by default, so paths must be adjusted accordingly.